### PR TITLE
Add numeric gossip hotkeys

### DIFF
--- a/DialogKey.toc
+++ b/DialogKey.toc
@@ -1,6 +1,6 @@
-## Interface: 60200
+## Interface: 30300
 ## Title: DialogKey
-## Notes: Lets you set a key that also confirms loot/purchase dialogs, accept/complete quests, etc. Spacebar to complete quests? Easy!
+## Notes: Press Spacebar to accept or complete quests and 1-9 to select gossip options.
 ## Author: Foxthorn
 ## Version: 1.0
 ## SavedVariables: DialogKeyDB

--- a/core.lua
+++ b/core.lua
@@ -337,20 +337,40 @@ function DialogKey:UnwatchFrame(name)		-- Remove given frame from the watch list
 	
 	self:UpdateAdditionalFrames()
 end
-
 -- Primary functions --
-function DialogKey:HandleKey(key)			-- Run for every key hit ever; runs ClickButtons() if it's the bound one
-	if DialogKey.keybindMode then
-		DialogKey:HandleKeybind(key)
-		return
-	end
-	
-	if key == DialogKey.db.global.keys[1] or key == DialogKey.db.global.keys[2] then
-		local success = DialogKey:ClickButtons()
-		self:SetPropagateKeyboardInput(not success)
-	else
-		self:SetPropagateKeyboardInput(true)
-	end
+
+function DialogKey:HandleKey(key)                       -- Run for every key hit ever; runs ClickButtons() if it's the bound one
+        if DialogKey.keybindMode then
+                DialogKey:HandleKeybind(key)
+                return
+        end
+
+        -- Handle numeric keys (1-9) for gossip dialog options
+        local numKey = tonumber(key)
+        if not numKey then
+                local npMatch = string.match(key, "NUMPAD(%d)")
+                if npMatch then
+                        numKey = tonumber(npMatch)
+                end
+        end
+        if numKey and numKey >= 1 and numKey <= 9 then
+                if GossipFrame and GossipFrame:IsShown() then
+                        local button = _G["GossipTitleButton" .. numKey]
+                        if button and button:IsVisible() then
+                                self:Glow(button, "click")
+                                button:Click()
+                                self:SetPropagateKeyboardInput(false)
+                                return
+                        end
+                end
+        end
+
+        if key == DialogKey.db.global.keys[1] or key == DialogKey.db.global.keys[2] then
+                local success = DialogKey:ClickButtons()
+                self:SetPropagateKeyboardInput(not success)
+        else
+                self:SetPropagateKeyboardInput(true)
+        end
 end
 
 function DialogKey:ClickButtons()			-- Main function to click on dialog buttons when the bound key is pressed


### PR DESCRIPTION
## Summary
- allow pressing 1-9 (and numpad) to pick corresponding gossip options
- keep Spacebar functionality for accepting and completing quests
- adjust addon interface version for WotLK 3.3.5a

## Testing
- `luac -p core.lua`

------
https://chatgpt.com/codex/tasks/task_e_688a6e35acdc83229f22c19d4389e01b